### PR TITLE
CODEBOOTER: Made a limit to Jobs and Internship section on HomeScreen

### DIFF
--- a/lib/Client/Screens/jobs/JobInternship.dart
+++ b/lib/Client/Screens/jobs/JobInternship.dart
@@ -13,7 +13,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 class JobInternships extends StatefulWidget {
-  const JobInternships({Key? key}) : super(key: key);
+  final int value;
+  const JobInternships({Key? key, required this.value}) : super(key: key);
 
   @override
   State<JobInternships> createState() => _JobInternshipsState();
@@ -49,10 +50,10 @@ class _JobInternshipsState extends State<JobInternships> {
             if (state is JobLoadedState) {
               List<JobModel> jobList = state.jobs;
               // print(jobList[1].imageAsset);
-
+              int itemNum=widget.value<jobList.length?widget.value:jobList.length;
               return Column(
                 children: [
-                  ...jobList.map((job) => _buildFeatureContainer(
+                  ...jobList.take(itemNum).map((job) => _buildFeatureContainer(
                         title: job.title,
                         imageAsset: job.imageAsset,
                         stipend: job.stipend,

--- a/lib/Client/home/HomeScreen.dart
+++ b/lib/Client/home/HomeScreen.dart
@@ -116,7 +116,25 @@ class _HomeScreenState extends State<HomeScreen> {
                     ],
                   ),
                 ),
-                const JobInternships(),
+                const JobInternships(value: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    TextButton(
+                      onPressed: () => context.go('/jobinternship'),
+                      child: Text(
+                        "Show More",
+                        style: TextStyle(
+                          fontFamily: 'poppins',
+                          fontSize: dimension.font16,
+                          fontWeight: FontWeight.w400,
+                          color: Colors.blue,
+                        ),
+                      ),
+                    ),
+                    Icon(Icons.arrow_forward_ios, color: Colors.blue,size: dimension.font16,)
+                  ],
+                )
               ],
             ),
           ),

--- a/lib/Client/home/JobInternshipScreen.dart
+++ b/lib/Client/home/JobInternshipScreen.dart
@@ -41,7 +41,7 @@ class _DsaScreenState extends State<JobInternshipScreen> {
       body: SingleChildScrollView(
         child: Padding(
             padding: EdgeInsets.only(left: dimension.val10),
-            child: const JobInternships()),
+            child: const JobInternships(value: 10000,)),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -524,18 +524,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -761,10 +761,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: transitive
     description:
@@ -881,10 +881,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -997,6 +997,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.5"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   webview_flutter:
     dependency: transitive
     description:
@@ -1078,5 +1086,5 @@ packages:
     source: hosted
     version: "8.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.0"


### PR DESCRIPTION
### Description
This merge request addresses the issue #86, which is about introducing a feature to limit the number of displayed Jobs and Internships on HomeScreen in the 'JobInternships' widget. It provides the ability to choose the maximum number of items to display. If no limit is specified, all items will be shown.

### Changes Made
- Added a new parameter, 'value', to the 'JobInternships' widget.
- When 'value' is set to a positive integer, it limits the number of displayed items.
- When 'value' is provided with max number, all items are displayed.

### Testing
I tested this feature by setting 'value' to various positive integers. The widget behaved as expected, displaying the correct number of items or all items when no limit was set.

### Discussion
I welcome feedback and suggestions on this feature. If you have any questions or concerns, please let me know.

/cc @Manav-khadka 
